### PR TITLE
Specify samples, maximum duration of tests and tests disabling options using command line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rmf_traffic REQUIRED)
 find_package(rmf_fleet_adapter REQUIRED)
+find_package(Boost COMPONENTS program_options REQUIRED)
 
 include(GNUInstallDirs)
 
@@ -69,6 +70,7 @@ target_link_libraries(
     PRIVATE
     rmf_traffic::rmf_traffic
     rmf_fleet_adapter::rmf_fleet_adapter
+    ${Boost_LIBRARIES}
 )
 
 target_include_directories(

--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-select=rmf_perfo
 
 ```bash
 cd {ros2_ws}
-./install/rmf_performance_tests/lib/rmf_performance_tests/test_planner {SCENARIO_NAME}
+./install/rmf_performance_tests/lib/rmf_performance_tests/test_planner --scenario={SCENARIO_NAME} --samples={NUM_SAMPLES} --max_duration={MAX_DURATION_IN_SECONDS}
 ```

--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-select=rmf_perfo
 cd {ros2_ws}
 ./install/rmf_performance_tests/lib/rmf_performance_tests/test_planner --scenario={SCENARIO_NAME} --samples={NUM_SAMPLES} --max_duration={MAX_DURATION_IN_SECONDS}
 ```
+
+#### Additional Aguements
+
+- `-o`: will disable obstacles tests
+- `+o`: will only run tests with obstacles
+- `-c`: will disable cache tests
+- `+c`: will only run tests with cache

--- a/include/rmf_performance_tests/Scenario.hpp
+++ b/include/rmf_performance_tests/Scenario.hpp
@@ -43,6 +43,7 @@ struct Route
 struct Description
 {
   std::size_t samples;
+  std::optional<rmf_traffic::Duration> max_duration;
 
   std::unordered_map<std::string,
     rmf_traffic::agv::Planner::Configuration> robots;
@@ -52,6 +53,13 @@ struct Description
   Plan plan;
 };
 
+struct Arguments
+{
+  std::string scenario_file;
+  std::optional<std::size_t> samples;
+  std::optional<double> max_duration;
+};
+
 bool load(std::string file_name, YAML::Node& node);
 
 bool load_graph(
@@ -59,7 +67,9 @@ bool load_graph(
   rmf_traffic::agv::VehicleTraits traits,
   rmf_traffic::agv::Graph& graph);
 
-void parse(std::string scenario_file, Description& description);
+Arguments parse_arguments(int argc, char* argv[]);
+
+void parse(Arguments arguments, Description& description);
 
 }
 }

--- a/include/rmf_performance_tests/Scenario.hpp
+++ b/include/rmf_performance_tests/Scenario.hpp
@@ -58,6 +58,10 @@ struct Arguments
   std::string scenario_file;
   std::optional<std::size_t> samples;
   std::optional<double> max_duration;
+  bool include_no_obstacle_tests = true;
+  bool include_obstacle_tests = true;
+  bool include_no_cache_tests = true;
+  bool include_cache_tests = true;
 };
 
 bool load(std::string file_name, YAML::Node& node);
@@ -66,6 +70,8 @@ bool load_graph(
   std::string file_name,
   rmf_traffic::agv::VehicleTraits traits,
   rmf_traffic::agv::Graph& graph);
+
+std::pair<std::string, std::string> parse_test_options(const std::string& args);
 
 Arguments parse_arguments(int argc, char* argv[]);
 

--- a/include/rmf_performance_tests/rmf_performance_tests.hpp
+++ b/include/rmf_performance_tests/rmf_performance_tests.hpp
@@ -45,6 +45,7 @@ void print_result(
 double test_planner_timing_no_cache(
   const std::string& label,
   const std::size_t samples,
+  const std::optional<rmf_traffic::Duration> max_duration,
   const rmf_traffic::agv::Planner::Configuration& config,
   const rmf_traffic::agv::Planner::Options& options,
   const rmf_traffic::agv::Plan::Start& start,
@@ -53,6 +54,7 @@ double test_planner_timing_no_cache(
 double test_planner_timing_with_cache(
   const std::string& label,
   const std::size_t samples,
+  const std::optional<rmf_traffic::Duration> max_duration,
   const rmf_traffic::agv::Planner::Configuration& config,
   const rmf_traffic::agv::Planner::Options& options,
   const rmf_traffic::agv::Plan::Start& start,
@@ -61,6 +63,7 @@ double test_planner_timing_with_cache(
 void test_planner_timing(
   const std::string& label,
   const std::size_t samples,
+  const std::optional<rmf_traffic::Duration> max_duration,
   const rmf_traffic::agv::Planner::Configuration& config,
   const rmf_traffic::agv::Planner::Options& options,
   const rmf_traffic::agv::Plan::Start& start,
@@ -69,6 +72,7 @@ void test_planner_timing(
 void test_planner(
   const std::string& label,
   const std::size_t samples,
+  const std::optional<rmf_traffic::Duration> max_duration,
   const rmf_traffic::agv::Graph& graph,
   const rmf_traffic::agv::VehicleTraits& traits,
   const std::shared_ptr<rmf_traffic::schedule::Database>& database,

--- a/include/rmf_performance_tests/rmf_performance_tests.hpp
+++ b/include/rmf_performance_tests/rmf_performance_tests.hpp
@@ -38,14 +38,14 @@ rmf_traffic::schedule::Participant add_obstacle(
 
 void print_result(
   const std::string& label,
-  const std::size_t samples,
-  const double total_time,
-  const std::size_t node_count);
+  const std::size_t& samples,
+  const double& total_time,
+  const std::size_t& node_count);
 
 double test_planner_timing_no_cache(
   const std::string& label,
-  const std::size_t samples,
-  const std::optional<rmf_traffic::Duration> max_duration,
+  const std::size_t& samples,
+  const std::optional<rmf_traffic::Duration>& max_duration,
   const rmf_traffic::agv::Planner::Configuration& config,
   const rmf_traffic::agv::Planner::Options& options,
   const rmf_traffic::agv::Plan::Start& start,
@@ -53,8 +53,8 @@ double test_planner_timing_no_cache(
 
 double test_planner_timing_with_cache(
   const std::string& label,
-  const std::size_t samples,
-  const std::optional<rmf_traffic::Duration> max_duration,
+  const std::size_t& samples,
+  const std::optional<rmf_traffic::Duration>& max_duration,
   const rmf_traffic::agv::Planner::Configuration& config,
   const rmf_traffic::agv::Planner::Options& options,
   const rmf_traffic::agv::Plan::Start& start,
@@ -62,22 +62,28 @@ double test_planner_timing_with_cache(
 
 void test_planner_timing(
   const std::string& label,
-  const std::size_t samples,
-  const std::optional<rmf_traffic::Duration> max_duration,
+  const std::size_t& samples,
+  const std::optional<rmf_traffic::Duration>& max_duration,
   const rmf_traffic::agv::Planner::Configuration& config,
   const rmf_traffic::agv::Planner::Options& options,
   const rmf_traffic::agv::Plan::Start& start,
-  const rmf_traffic::agv::Plan::Goal& goal);
+  const rmf_traffic::agv::Plan::Goal& goal,
+  const bool& include_cache_tests,
+  const bool& include_no_cache_tests);
 
 void test_planner(
   const std::string& label,
-  const std::size_t samples,
-  const std::optional<rmf_traffic::Duration> max_duration,
+  const std::size_t& samples,
+  const std::optional<rmf_traffic::Duration>& max_duration,
   const rmf_traffic::agv::Graph& graph,
   const rmf_traffic::agv::VehicleTraits& traits,
   const std::shared_ptr<rmf_traffic::schedule::Database>& database,
   const rmf_traffic::agv::Plan::Start& start,
-  const rmf_traffic::agv::Plan::Goal& goal);
+  const rmf_traffic::agv::Plan::Goal& goal,
+  const bool& include_obstacle_tests,
+  const bool& include_no_obstacle_tests,
+  const bool& include_cache_tests,
+  const bool& include_no_cache_tests);
 
 std::string get_map_directory();
 

--- a/src/rmf_performance_tests.cpp
+++ b/src/rmf_performance_tests.cpp
@@ -66,9 +66,9 @@ rmf_traffic::schedule::Participant add_obstacle(
 
 void print_result(
   const std::string& label,
-  const std::size_t samples,
-  const double total_time,
-  const std::size_t node_count)
+  const std::size_t& samples,
+  const double& total_time,
+  const std::size_t& node_count)
 {
   std::cout << label
             << "\n -- Total time for " << samples << " samples: "
@@ -80,8 +80,8 @@ void print_result(
 
 double test_planner_timing_no_cache(
   const std::string& label,
-  const std::size_t samples,
-  const std::optional<rmf_traffic::Duration> max_duration,
+  const std::size_t& samples,
+  const std::optional<rmf_traffic::Duration>& max_duration,
   const rmf_traffic::agv::Planner::Configuration& config,
   const rmf_traffic::agv::Planner::Options& options,
   const rmf_traffic::agv::Plan::Start& start,
@@ -126,7 +126,7 @@ double test_planner_timing_no_cache(
     {
     }
 
-    const auto p = wp.position();
+    const auto& p = wp.position();
     std::cout << " (" << p[0] << ", " << p[1] << ")";
 
     std::cout << " -> ";
@@ -147,8 +147,8 @@ double test_planner_timing_no_cache(
 
 double test_planner_timing_with_cache(
   const std::string& label,
-  const std::size_t samples,
-  const std::optional<rmf_traffic::Duration> max_duration,
+  const std::size_t& samples,
+  const std::optional<rmf_traffic::Duration>& max_duration,
   const rmf_traffic::agv::Planner::Configuration& config,
   const rmf_traffic::agv::Planner::Options& options,
   const rmf_traffic::agv::Plan::Start& start,
@@ -187,58 +187,85 @@ double test_planner_timing_with_cache(
 
 void test_planner_timing(
   const std::string& label,
-  const std::size_t samples,
-  const std::optional<rmf_traffic::Duration> max_duration,
+  const std::size_t& samples,
+  const std::optional<rmf_traffic::Duration>& max_duration,
   const rmf_traffic::agv::Planner::Configuration& config,
   const rmf_traffic::agv::Planner::Options& options,
   const rmf_traffic::agv::Plan::Start& start,
-  const rmf_traffic::agv::Plan::Goal& goal)
+  const rmf_traffic::agv::Plan::Goal& goal,
+  const bool& include_cache_tests,
+  const bool& include_no_cache_tests)
 {
   std::cout << " --------- \n" << std::endl;
 
   // For each variation of test, we run many samples and then see what the
   // average time is.
-  const double no_cache_time = test_planner_timing_no_cache(
-    label, samples, max_duration, config, options, start, goal);
+  double no_cache_time;
+  if (include_no_cache_tests)
+  {
+    no_cache_time = test_planner_timing_no_cache(
+      label, samples, max_duration, config, options, start, goal);
+  }
 
-  const double with_cache_time = test_planner_timing_with_cache(
-    label, samples, max_duration, config, options, start, goal);
+  double with_cache_time;
+  if (include_cache_tests)
+  {
+    with_cache_time = test_planner_timing_with_cache(
+      label, samples, max_duration, config, options, start, goal);
+  }
 
-  std::cout << "Cache speed boost: x" << no_cache_time / with_cache_time
-            << "\n" << std::endl;
+  if (include_no_cache_tests && include_cache_tests)
+  {
+    std::cout << "Cache speed boost: x" << no_cache_time / with_cache_time
+              << "\n" << std::endl;
+  }
 }
 
 void test_planner(
   const std::string& label,
-  const std::size_t samples,
-  const std::optional<rmf_traffic::Duration> max_duration,
+  const std::size_t& samples,
+  const std::optional<rmf_traffic::Duration>& max_duration,
   const rmf_traffic::agv::Graph& graph,
   const rmf_traffic::agv::VehicleTraits& traits,
   const std::shared_ptr<rmf_traffic::schedule::Database>& database,
   const rmf_traffic::agv::Plan::Start& start,
-  const rmf_traffic::agv::Plan::Goal& goal)
+  const rmf_traffic::agv::Plan::Goal& goal,
+  const bool& include_obstacle_tests,
+  const bool& include_no_obstacle_tests,
+  const bool& include_cache_tests,
+  const bool& include_no_cache_tests)
 {
-  test_planner_timing(
-    label + " | No Obstacles",
-    samples,
-    max_duration,
-    {graph, traits},
-    {nullptr},
-    start, goal
-  );
+  if (include_no_obstacle_tests)
+  {
+    test_planner_timing(
+      label + " | No Obstacles",
+      samples,
+      max_duration,
+      {graph, traits},
+      {nullptr},
+      start, goal,
+      include_cache_tests,
+      include_no_cache_tests
+    );
+  }
 
-  const auto obstacle_validator =
-    rmf_traffic::agv::ScheduleRouteValidator::make(
-    database, NotObstacleID, traits.profile());
+  if (include_obstacle_tests)
+  {
+    const auto obstacle_validator =
+      rmf_traffic::agv::ScheduleRouteValidator::make(
+      database, NotObstacleID, traits.profile());
 
-  test_planner_timing(
-    label + " | With Obstacles",
-    samples,
-    max_duration,
-    {graph, traits},
-    {obstacle_validator},
-    start, goal
-  );
+    test_planner_timing(
+      label + " | With Obstacles",
+      samples,
+      max_duration,
+      {graph, traits},
+      {obstacle_validator},
+      start, goal,
+      include_cache_tests,
+      include_no_cache_tests
+    );
+  }
 }
 
 std::string get_map_directory()

--- a/test_planner.cpp
+++ b/test_planner.cpp
@@ -24,16 +24,12 @@
 
 int main(int argc, char* argv[])
 {
-  if (argc < 2)
-  {
-    std::cout << "Please provide scenario file name" << std::endl;
-    return 1;
-  }
+  auto arguments = rmf_performance_tests::scenario::parse_arguments(argc, argv);
 
   rmf_performance_tests::scenario::Description scenario;
   try
   {
-    parse(argv[1], scenario);
+    parse(arguments, scenario);
   }
   catch (std::runtime_error& e)
   {
@@ -129,6 +125,7 @@ int main(int argc, char* argv[])
   rmf_performance_tests::test_planner(
     plan.initial_waypoint + " -> " + plan.goal,
     scenario.samples,
+    scenario.max_duration,
     plan_robot->second.graph(), plan_robot->second.vehicle_traits(), database,
     {
       start_time + std::chrono::seconds(plan.initial_time),

--- a/test_planner.cpp
+++ b/test_planner.cpp
@@ -132,6 +132,10 @@ int main(int argc, char* argv[])
       get_wp(
         plan_robot->second.graph(), plan.initial_waypoint), plan.initial_orientation
     },
-    get_wp(plan_robot->second.graph(), plan.goal)
+    get_wp(plan_robot->second.graph(), plan.goal),
+    arguments.include_obstacle_tests,
+    arguments.include_no_obstacle_tests,
+    arguments.include_cache_tests,
+    arguments.include_no_cache_tests
   );
 }


### PR DESCRIPTION
This PR address [#2](https://github.com/osrf/rmf_performance_tests/issues/2) and [#4](https://github.com/osrf/rmf_performance_tests/issues/4) of [`osrf/rmf_performance_tests`](https://github.com/osrf/rmf_performance_tests).

It adds `scenario`, `samples` and `max_duration` as command line arguments:
- scenario : `--sceanrio`
- number of samples : `--samples`
- maximum duration : `--max_duration`

`max_duration` has higher priority over `samples`. As soon as the `max_duration` is elapsed, the remaining tests are suspended and the test results are reported based on the number of sample tests already run till that time. If the required number of sample tests finish before `max_duration`, the test exits normally.

Also adds `+o`, `-o`, `+c`, `-c` as arguments:
- `-o`: will disable obstacles tests
- `+o`: will only run tests with obstacles
- `-c`: will disable cache tests
- `+c`: will only run tests with cache